### PR TITLE
ui/ux: change 'Cancel' primary action on cancellation reason to 'Submit'

### DIFF
--- a/aptronics/public/js/aptronics_utils.js
+++ b/aptronics/public/js/aptronics_utils.js
@@ -43,7 +43,7 @@ aptronics.cancellation_reason_dialog = function (frm) {
 					user: frappe.session.user
 				});
 			},
-			primary_action_label: __('Cancel')
+			primary_action_label: __('Submit')
 		});
 		dialog.show();
 		dialog.get_close_btn().hide();


### PR DESCRIPTION
"Cancel the Cancel" was confusing users