### PR TITLE
Disallow file delete on submitted documents

### DIFF
--- a/aptronics/docs/developer/developer_guide.md
+++ b/aptronics/docs/developer/developer_guide.md
@@ -120,7 +120,7 @@ The Frappe community uses [conventional commits](https://www.conventionalcommits
   * perf
   * docs
 
-It neither uncommon nor required to add the _thing_ that is being changed into the prefix:
+Optionally, add the _thing_ that is being changed into the prefix:
 `feat(reports): add Gross Margin by Department report`
 
 Best practices dictate that changes should be relatively atomic, so it often makes sense to add one file at a time.

--- a/aptronics/files.py
+++ b/aptronics/files.py
@@ -1,0 +1,10 @@
+import frappe
+
+@frappe.whitelist()
+def confirm_delete_of_submitted_doc(doc, method):
+    linked_docstatus = frappe.get_value(
+        doc.attached_to_doctype, doc.attached_to_name, 'docstatus'
+    )
+    if linked_docstatus == 1:
+        frappe.permissions.check_admin_or_system_manager()
+        # frappe.throw("This file is attached to a submitted document.")

--- a/aptronics/hooks.py
+++ b/aptronics/hooks.py
@@ -125,6 +125,9 @@ doc_events = {
 	},
 	"Sales Invoice": {
 		"before_print": "aptronics.bundling.merge_bundled_items"
+	},
+	"File": {
+		"on_trash": "aptronics.files.confirm_delete_of_submitted_doc"
 	}
 }
 

--- a/aptronics/public/js/aptronics_utils.js
+++ b/aptronics/public/js/aptronics_utils.js
@@ -61,3 +61,9 @@ aptronics.provide_cancellation_reason = async function(frm){
 		frm.reload_doc();
 	});
 };
+
+aptronics.disallow_attachment_delete = function(frm){
+	if(frm.doc.docstatus == 1){
+		frm.$wrapper.find('.attachment-row').find('.close').hide()
+	}
+}

--- a/aptronics/public/js/custom/delivery_note_custom.js
+++ b/aptronics/public/js/custom/delivery_note_custom.js
@@ -2,6 +2,7 @@ frappe.ui.form.on("Delivery Note", {
 	refresh: (frm) => {
 		get_gita_wh(frm);
 		toggleNamingSeries(frm);
+		aptronics.disallow_attachment_delete(frm)
 	},
 	onload_post_render: (frm) => {
 		get_gita_wh(frm);

--- a/aptronics/public/js/custom/purchase_invoice_custom.js
+++ b/aptronics/public/js/custom/purchase_invoice_custom.js
@@ -1,6 +1,7 @@
 frappe.ui.form.on("Purchase Invoice", {
 	refresh: (frm) => {
 		aptronics.buyer_filter(frm);
+		aptronics.disallow_attachment_delete(frm);
 	},
 	is_return: (frm) => {
 		toggleNamingSeries(frm);

--- a/aptronics/public/js/custom/purchase_order_custom.js
+++ b/aptronics/public/js/custom/purchase_order_custom.js
@@ -2,6 +2,7 @@ frappe.ui.form.on("Purchase Order", {
 	refresh: (frm) => {
 		frm.set_df_property("drop_ship", "hidden", 0);
 		aptronics.buyer_filter(frm);
+		aptronics.disallow_attachment_delete(frm);
 	},
 	submit: (frm) => {
 		frm.set_df_property("drop_ship", "hidden", 0);

--- a/aptronics/public/js/custom/purchase_receipt_custom.js
+++ b/aptronics/public/js/custom/purchase_receipt_custom.js
@@ -2,6 +2,7 @@ frappe.ui.form.on("Purchase Receipt", {
 	refresh: (frm) => {
 		toggleNamingSeries(frm);
 		aptronics.buyer_filter(frm);
+		aptronics.disallow_attachment_delete(frm)
 	},
 	is_return: (frm) => {
 		toggleNamingSeries(frm);

--- a/aptronics/public/js/custom/quotation_custom.js
+++ b/aptronics/public/js/custom/quotation_custom.js
@@ -1,6 +1,9 @@
 {% include 'aptronics/public/js/bundling.js' %}
 
 frappe.ui.form.on("Quotation", {
+	refresh: (frm) =>{
+		aptronics.disallow_attachment_delete(frm)
+	},
 	before_cancel: (frm) => {
 		aptronics.provide_cancellation_reason(frm);
 	}

--- a/aptronics/public/js/custom/sales_invoice_custom.js
+++ b/aptronics/public/js/custom/sales_invoice_custom.js
@@ -6,7 +6,7 @@ frappe.ui.form.on("Sales Invoice", {
 	refresh: (frm) => {
 		frm.cscript.delivery_note_btn = patchDeliveryNoteBtn;
 		toggleNamingSeries(frm);
-		// confirm_non_git_items(frm);
+		aptronics.disallow_attachment_delete(frm)
 	},
 	is_return: (frm) => {
 		toggleNamingSeries(frm);

--- a/aptronics/public/js/custom/sales_order_custom.js
+++ b/aptronics/public/js/custom/sales_order_custom.js
@@ -4,6 +4,7 @@ frappe.ui.form.on("Sales Order", {
 	refresh: (frm) => {
 	 aptronics.buyer_filter(frm);
 	 set_default_delivery_date(frm);
+	 aptronics.disallow_attachment_delete(frm)
 	},
 	before_cancel: (frm) => {
 		aptronics.provide_cancellation_reason(frm);


### PR DESCRIPTION
This only allows administrator or sys admin roles to delete documents attached to submitted docs. 